### PR TITLE
test added for api key config

### DIFF
--- a/google_vision.install
+++ b/google_vision.install
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the google_vision module.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_requirements().
+ */
+function google_vision_requirements($phase) {
+  $requirements = array();
+  if ($phase == 'runtime') {
+    $key = \Drupal::config('google_vision.settings')->get('api_key');
+    if(!$key) {
+      $requirements['google_vision'] = array(
+        'title' => t('Google Vision API'),
+        'severity' => REQUIREMENT_ERROR,
+        'description' => t('Google Vision API key is not set and it is required for some functionalities to work. Please set it up at the <a href=":settings">Google Vision module settings page</a>.', array(
+        ':settings' => Url::fromRoute('google_vision.settings')->toString(),
+        )),
+      );
+    }
+  }
+  return $requirements;
+}

--- a/src/Tests/ApiKeyConfigurationTest.php
+++ b/src/Tests/ApiKeyConfigurationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\google_vision\Tests;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Url;
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Tests whether API key is set at the admin configuration page.
+ *
+ * @group google_vision
+ */
+class ApiKeyConfigurationTest extends WebTestBase {
+
+  /**
+   * Modules to install.
+   *
+   * @var array
+   */
+  public static $modules = ['google_vision'];
+
+  /**
+   * Disable strict config schema checking.
+   *
+   * The schema is verified at the end of running the update.
+   *
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * A user with permission to create and edit books and to administer blocks.
+   *
+   * @var object
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Creates administrative user.
+    $this->adminUser = $this->drupalCreateUser(array('administer google vision','administer site configuration')
+    );
+    $this->drupalLogin($this->adminUser);
+  }
+
+  /**
+   * Test to implement a runtime requirement checking if API key is not set.
+   */
+  function testKeyConfiguration() {
+    $this->drupalGet(Url::fromRoute('google_vision.settings'));
+    $this->assertResponse(200);
+    $this->assertFieldByName('api_key', '', 'The API key is not set');
+    $this->drupalGet(Url::fromRoute('system.status'));
+    $this->assertResponse(200);
+    $this->assertText('Google Vision API key is not set and it is required for some functionalities to work.', 'The content exists on the report page');
+    $this->assertLink('Google Vision module settings page', 0, 'Link to the api key configuration page found');
+    $this->assertLinkByHref(Url::fromRoute('google_vision.settings')->toString());
+
+  }
+
+  /**
+   * Test to verify that it is stored successfully.
+   */
+  function testKeyStorage() {
+    $this->drupalGet(Url::fromRoute('google_vision.settings'));
+    $this->assertResponse(200);
+    $this->assertFieldByName('api_key', '', 'The key is not set currently');
+    $apiKey = $this->randomString(40);
+    $data = array(
+      'api_key' => $apiKey,
+    );
+    $this->drupalPostForm(Url::fromRoute('google_vision.settings'), $data, t('Save configuration'));
+    $this->drupalGet(Url::fromRoute('google_vision.settings'));
+    $this->assertResponse(200);
+    $this->assertFieldByName('api_key', $apiKey, 'The key has been saved');
+  }
+}


### PR DESCRIPTION
1. Test whether error report is generated if the key is missing.
2. Also, set a dummy key and check if it is saved or not.
